### PR TITLE
Problems with latest python / Django / distutils ?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'password_required',
     ],
     package_data={
-        'password_required': ['templates/password_required/*'],
+        'password_required': ['templates/*'],
     },
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Hey @mikl .. thanks for this useful app, I use it on occasion. I'm doing a deployment on a Python 2.7, Django 1.6.5 and this time it's having trouble:

TemplateDoesNotExist at /password_required/

Django tried loading these templates, in this order:
Using loader django.template.loaders.filesystem.Loader:
/var/www/myapp/templates/password_required_login.html (File does not exist)
Using loader django.template.loaders.app_directories.Loader:
/usr/local/lib/python2.7/dist-packages/django/contrib/admin/templates/password_required_login.html (File does not exist)
/usr/local/lib/python2.7/dist-packages/django/contrib/auth/templates/password_required_login.html (File does not exist)
/usr/local/lib/python2.7/dist-packages/crispy_forms/templates/password_required_login.html (File does not exist)

So first thing I notice, the .html file isn't included in the install anymore - this fix?
But even after that, Django doesn't know where to look for the template.

For now I have a workaround by copying your .html template to my /var/www/myapp/templates/ folder..

Cheers,
TTimo
