### PR TITLE
Add support for Django 3.0

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -59,7 +59,7 @@ Usage
 Requirements
 ------------
 
-This app requires Django 1.2 or later.
+This app requires Python 3 and Django 1.5 or later.
 
 
 License
@@ -77,8 +77,8 @@ issue on the [main Github repo][repo].
 [Django]: http://www.djangoproject.com/
 [pip]: http://pip.openplans.org/
 [virtualenv]: http://pypi.python.org/pypi/virtualenv
-[settings]: http://docs.djangoproject.com/en/1.2/topics/settings/
-[URLconf]: http://docs.djangoproject.com/en/1.2/topics/http/urls/#topics-http-urls
+[settings]: http://docs.djangoproject.com/en/1.5/topics/settings/
+[URLconf]: http://docs.djangoproject.com/en/1.5/topics/http/urls/#topics-http-urls
 [BSD]: http://www.opensource.org/licenses/bsd-license.php
 [repo]: http://github.com/mikl/django-password-required
 

--- a/password_required/decorators.py
+++ b/password_required/decorators.py
@@ -4,7 +4,6 @@ from functools import update_wrapper, wraps
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.urls import reverse
 from django.http import HttpResponseRedirect
-from django.utils.decorators import available_attrs
 from django.utils.http import urlquote
 
 def password_required(view_func=None, redirect_field_name=REDIRECT_FIELD_NAME):
@@ -21,5 +20,5 @@ def password_required(view_func=None, redirect_field_name=REDIRECT_FIELD_NAME):
             redirect_field_name,
             urlquote(request.get_full_path()),
         ))
-    return wraps(view_func, assigned=available_attrs(view_func))(_wrapped_view)
+    return wraps(view_func)(_wrapped_view)
 


### PR DESCRIPTION
Django 3.0 drops support for Python 2 and removes the compatibility function `available_attrs`. This pull request will allow password-required to work with Django 3 but it will stop working with Python 2.